### PR TITLE
Bug in CompositeContainer if no sub-container

### DIFF
--- a/src/CompositeContainer.php
+++ b/src/CompositeContainer.php
@@ -13,7 +13,7 @@ class CompositeContainer implements ContainerInterface
     /**
      * @var array Containers that are contained within this composite container
      */
-    protected $containers;
+    protected $containers = array();
 
     /**
      * @param array $containers Containers to add to this composite container

--- a/tests/CompositeContainerTest.php
+++ b/tests/CompositeContainerTest.php
@@ -35,4 +35,14 @@ class CompositeContainerTest extends \PHPUnit_Framework_TestCase
         $this->setExpectedException('Interop\Container\Exception\NotFoundException');
         $container->get('foo');
     }
+
+    public function testNoSubContainers()
+    {
+        $container = new CompositeContainer();
+
+        $this->assertFalse($container->has('foo'));
+
+        $this->setExpectedException('Interop\Container\Exception\NotFoundException');
+        $container->get('foo');
+    }
 }


### PR DESCRIPTION
Fixed a bug when a CompositeContainer was called without sub-containers.
