### PR TITLE
Added Phalcon DI Container Adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,6 +176,7 @@ Command design pattern. You can also use the `FailoverOnMissContainer` decorator
 * [Symfony Dependency Injection Container](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/DependencyInjection/ContainerInterface.php)
 * [ZF2 Service Manager](https://github.com/zendframework/zf2/blob/master/library/Zend/ServiceManager/ServiceLocatorInterface.php)
 * [ZF2 Dependency Injection](https://github.com/zendframework/zf2/blob/master/library/Zend/Di/ServiceLocatorInterface.php)
+* [Phalcon DI](http://docs.phalconphp.com/en/latest/api/Phalcon_DiInterface.html)
 * Any other container-like object that implements `ArrayAccess` (see [`ArrayAccess` in the PHP Manual](http://php.net/manual/en/class.arrayaccess.php))
 
 ### What if the Container I use is not supported?

--- a/src/Adapter/PhalconDIContainerAdapter.php
+++ b/src/Adapter/PhalconDIContainerAdapter.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace Acclimate\Container\Adapter;
+
+use Interop\Container\ContainerInterface as AcclimateContainerInterface;
+use Acclimate\Container\Exception\NotFoundException as AcclimateNotFoundException;
+use Acclimate\Container\Exception\ContainerException as AcclimateContainerException;
+
+use Phalcon\DiInterface as PhalconDI;
+use Phalcon\DI\Exception as PhalconDIException;
+
+/**
+ * An adapter from an object implementing Phalcon\DiInterface to the standardized ContainerInterface
+ */
+class PhalconDIContainerAdapter implements AcclimateContainerInterface
+{
+    /**
+     * @var \Phalcon\DiInterface Phalcons DI container object
+     */
+    private $container;
+
+    /**
+     * @param \Phalcon\DiInterface $container
+     */
+    public function __construct(PhalconDI $container)
+    {
+        $this->container = $container;
+    }
+
+    public function get($id)
+    {
+        try {
+            return $this->container->get($id);
+        } catch(PhalconDIException $prev) {
+            throw AcclimateNotFoundException::fromPrevious($id);
+        } catch (\Exception $prev) {
+            throw AcclimateContainerException::fromPrevious($id, $prev);
+        }
+    }
+
+    public function has($id)
+    {
+        return isset($this->container[$id]);
+    }
+}

--- a/src/Adapter/map.php
+++ b/src/Adapter/map.php
@@ -17,5 +17,6 @@ return array(
     'DI\Container' => 'Acclimate\Container\Adapter\PHPDIContainerAdapter',
     'Nette\DI\Container' => 'Acclimate\Container\Adapter\NetteContainerAdapter',
     'ArrayAccess' => 'Acclimate\Container\Adapter\ArrayAccessContainerAdapter',
+    'Phalcon\DiInterface' => 'Acclimate\Container\Adapter\PhalconDIContainerAdapter'
 );
 // @codeCoverageIgnoreEnd

--- a/tests/Adapter/PhalconDIContainerAdapterTest.php
+++ b/tests/Adapter/PhalconDIContainerAdapterTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Acclimate\Container\Test\Adapter;
+
+use Acclimate\Container\Adapter\PhalconDIContainerAdapter;
+use Phalcon\DI as PhalconDI;
+
+/**
+ * @requires extension phalcon
+ */
+class PhalconDIContainerAdapterTest extends AbstractContainerAdapterTest {
+    
+    protected function createContainer()
+    {
+        $container = new PhalconDI();
+        $container->setShared('array_iterator', new \ArrayIterator(range(1, 5)));
+        $container->set('error', function() {
+            throw new \RuntimeException;
+        });
+
+        return new PhalconDIContainerAdapter($container);
+    }
+
+}


### PR DESCRIPTION
One issue in this commit is, that as Phalcon cannot be just installed using composer, as it needs to be compiled, I made the tests skippable if phalcon is not present using the following comment

    /**
     * @requires extension phalcon
     */

That produces three `S` (skipped) in the command line test runner. I have not found a nicer method. 