### PR TITLE
Adding delegate-lookup support to ArrayContainer

### DIFF
--- a/src/ArrayContainer.php
+++ b/src/ArrayContainer.php
@@ -17,13 +17,19 @@ class ArrayContainer implements ContainerInterface, \ArrayAccess
      * @var array|\ArrayAccess The container data
      */
     protected $data;
+    
+    /**
+     * @var ContainerInterface The container that will be used for dependency lookups
+     */
+    protected $delegateLookupContainer;
 
     /**
      * @param array|\ArrayAccess|\Traversable $data Data for the container
+     * @param ContainerInterface $delegateLookupContainer The container that will be used for dependency lookups.
      *
      * @throws \InvalidArgumentException if the provided data is not an array or array-like object
      */
-    public function __construct($data = array())
+    public function __construct($data = array(), $delegateLookupContainer = null)
     {
         if (is_array($data) || $data instanceof \ArrayAccess) {
             $this->data = $data;
@@ -32,6 +38,7 @@ class ArrayContainer implements ContainerInterface, \ArrayAccess
         } else {
             throw new \InvalidArgumentException('The ArrayContainer requires either an array or an array-like object');
         }
+        $this->delegateLookupContainer = $delegateLookupContainer ?: $this;
     }
 
     public function get($id)
@@ -39,7 +46,7 @@ class ArrayContainer implements ContainerInterface, \ArrayAccess
         if (isset($this->data[$id])) {
             try {
                 if ($this->data[$id] instanceof \Closure) {
-                    $this->data[$id] = call_user_func($this->data[$id], $this);
+                    $this->data[$id] = call_user_func($this->data[$id], $this->delegateLookupContainer);
                 }
             } catch (\Exception $prev) {
                 throw ContainerException::fromPrevious($id, $prev);

--- a/tests/ArrayContainerTest.php
+++ b/tests/ArrayContainerTest.php
@@ -4,6 +4,7 @@ namespace Acclimate\Container\Test;
 
 use Acclimate\Container\ArrayContainer;
 use Acclimate\Container\Test\Adapter\AbstractContainerAdapterTest;
+use Interop\Container\ContainerInterface; 
 
 /**
  * @covers \Acclimate\Container\ArrayContainer
@@ -81,5 +82,18 @@ class ArrayContainerTest extends \PHPUnit_Framework_TestCase
         $this->assertInstanceOf('stdClass', $baz);
         $this->assertEquals('bar', $baz->foo);
         $this->assertSame($baz, $container['baz']);
+    }
+    
+    public function testDelegateLookupFeature() {
+    	$container1 = new ArrayContainer([
+    			'foo' => 'bar'
+    	]);
+    	$container2 = new ArrayContainer([
+    			'baz' => function(ContainerInterface $container) {
+    				return $container->get('foo');
+    			}
+    	], $container1);
+    	
+    	$this->assertEquals('bar', $container2->get('baz'));
     }
 }


### PR DESCRIPTION
Hi Jeremy,

Following the release of container-interop 1.1 that adds the [delegate-lookup feature](https://github.com/container-interop/container-interop/blob/master/docs/Delegate-lookup.md), I just stumbled on your ArrayContainer class and could not resist the temptation to add support for this feature in your class.

Quite simple really. Hope you will like it and accept this pull request :)
Ho, and unit tests are here too!