### PR TITLE
Deprecating Guzzle

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,6 @@ Command design pattern. You can also use the `FailoverOnMissContainer` decorator
 ## Supported Containers
 
 * [Aura.Di Container](https://github.com/auraphp/Aura.Di/blob/develop/src/Aura/Di/ContainerInterface.php)
-* [Guzzle Service Builder](https://github.com/guzzle/service/blob/master/Builder/ServiceBuilderInterface.php)
 * [Laravel Container](https://github.com/laravel/framework/blob/master/src/Illuminate/Container/Container.php)
 * [Nette DI Container](https://github.com/nette/nette/blob/master/Nette/DI/Container.php)
 * [PHP-DI Container](https://github.com/mnapoli/PHP-DI/blob/master/src/DI/Container.php)
@@ -183,6 +182,12 @@ Command design pattern. You can also use the `FailoverOnMissContainer` decorator
 
 Also, the [Silex Application](https://github.com/fabpot/Silex/blob/master/src/Silex/Application.php) and other projects
 descending from Pimple can be used with Acclimate as well.
+
+## Deprecated Containers
+
+Support for the following containers is deprecated in version 1.1, and will be removed in 2.0:
+
+* [Guzzle Service Builder](https://github.com/guzzle/service/blob/master/Builder/ServiceBuilderInterface.php)
 
 ### What if the Container I use is not supported?
 

--- a/src/Adapter/GuzzleContainerAdapter.php
+++ b/src/Adapter/GuzzleContainerAdapter.php
@@ -9,6 +9,7 @@ use Guzzle\Service\Exception\ServiceNotFoundException as GuzzleNotFoundException
 use Interop\Container\ContainerInterface as AcclimateContainerInterface;
 
 /**
+ * @deprecated in v1.1
  * An adapter from a Guzzle ServiceBuilder to the standardized ContainerInterface
  */
 class GuzzleContainerAdapter implements AcclimateContainerInterface


### PR DESCRIPTION
As per discussion, marking Guzzle 3 as deprecated for v1.1.  Will remove in v2.0.  This is because Guzzle 6, the latest version, does not have a container.