### PR TITLE
Switch from Container-Interop to PSR-11

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,15 +27,18 @@ items from the container objects of third-party libraries. That's interoperabili
 ## The Container Interface
 
 The `ContainerInterface` used by Acclimate comes from the
-[`container-interop/container-interop`](https://github.com/container-interop/container-interop) project. It attempts
+[`psr/container`](https://github.com/php-fig/container) project. It attempts
 to normalize the various implementations of container interfaces (whether they be for service locators, dependency
 injection containers, or something else similar) to a simple, readonly interface, that allows users to retrieve
 entries from any third-party container in a consistent way.
 
+Acclimate v1 and previous use the similar
+[`container-interop/container-interop`](https://github.com/container-interop/container-interop) standard
+
 The `ContainerInterface` looks like this:
 
 ```php
-namespace Interop\Container;
+namespace Psr\Container;
 
 interface ContainerInterface
 {
@@ -58,7 +61,7 @@ interface ContainerInterface
 ## Installation
 
 Install the `acclimate/container` package using Composer. This will also also install
-`container-interop/container-interop`, which provides the `ContainerInterface`.
+`psr/container`, which provides the `ContainerInterface`.
 
 **Warning:** If you install Acclimate with dev dependencies, you will get A LOT of packages from various frameworks
 (e.g., ZF, Symfony, Laravel, etc.). These packages are *required for testing only* to ensure that all of the adapter
@@ -104,7 +107,7 @@ Now you can use the container from your favorite framework and acclimate it into
 ## Container Decorators
 
 The default behavior of a container implementing the `ContainerInterface` is to throw a
-`Interop\Container\Exception\NotFoundException` when using `get()` to retrieve an entry that does not actually exist in
+`Psr\Container\NotFoundExceptionInterface` when using `get()` to retrieve an entry that does not actually exist in
 the container. In some cases, you may want to change this default behavior to do something else instead (e.g., return
 `null`). Container decorators allow you to easily modify the behavior of a container. `acclimate\container` ships with
 3 decorators (`NullOnMissContainer`, `CallbackOnMissContainer`, and `FailoverOnMissContainer`), but allows you to easily
@@ -120,7 +123,7 @@ require 'vendor/autoload.php';
 
 use Acclimate\Container\ArrayContainer;
 use Acclimate\Container\Decorator\NullOnMissContainer;
-use Interop\Container\Exception\NotFoundException;
+use Psr\Container\NotFoundExceptionInterface;
 
 // Create an empty, basic container following the `ContainerInterface`
 $container = new ArrayContainer();
@@ -128,7 +131,7 @@ $container = new ArrayContainer();
 // Normally, this container will throw an exception on missing items
 try {
     $item = $container->get('foo');
-} catch (NotFoundException $e) {
+} catch (NotFoundExceptionInterface $e) {
     echo $e->getMessage() . "\n";
 }
 # There is no entry found in the container for the identifier "foo".
@@ -214,5 +217,6 @@ $adaptedContainer = $acclimator->acclimate($container);
 
 ## Resources
 
+* [PSR-11 project](https://github.com/php-fig/container)
 * [Container Interop project](https://github.com/container-interop/container-interop)
 * [Service container usage comparison](https://gist.github.com/mnapoli/6159681)

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "container-interop/container-interop": "^1.0"
+        "psr/container": "^1.0"
     },
     "require-dev": {
         "aura/di": "^1.0",

--- a/src/Adapter/ArrayAccessContainerAdapter.php
+++ b/src/Adapter/ArrayAccessContainerAdapter.php
@@ -2,7 +2,7 @@
 
 namespace Acclimate\Container\Adapter;
 
-use Interop\Container\ContainerInterface as AcclimateContainerInterface;
+use Psr\Container\ContainerInterface as AcclimateContainerInterface;
 use Acclimate\Container\Exception\NotFoundException as AcclimateNotFoundException;
 use Acclimate\Container\Exception\ContainerException as AcclimateContainerException;
 

--- a/src/Adapter/AuraContainerAdapter.php
+++ b/src/Adapter/AuraContainerAdapter.php
@@ -6,7 +6,7 @@ use Acclimate\Container\Exception\ContainerException as AcclimateContainerExcept
 use Acclimate\Container\Exception\NotFoundException as AcclimateNotFoundException;
 use Aura\Di\ContainerInterface as AuraContainerInterface;
 use Aura\Di\Exception\ServiceNotFound as AuraNotFoundException;
-use Interop\Container\ContainerInterface as AcclimateContainerInterface;
+use Psr\Container\ContainerInterface as AcclimateContainerInterface;
 
 /**
  * An adapter from an Aura DIC to the standardized ContainerInterface

--- a/src/Adapter/LaravelContainerAdapter.php
+++ b/src/Adapter/LaravelContainerAdapter.php
@@ -5,12 +5,12 @@ namespace Acclimate\Container\Adapter;
 use Acclimate\Container\Exception\ContainerException as AcclimateContainerException;
 use Acclimate\Container\Exception\NotFoundException as AcclimateNotFoundException;
 use Illuminate\Container\Container as LaravelContainerInterface;
-use Interop\Container\ContainerInterface as AcclimateContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * An adapter from a Laravel Container to the standardized ContainerInterface
  */
-class LaravelContainerAdapter implements AcclimateContainerInterface
+class LaravelContainerAdapter implements ContainerInterface
 {
     /**
      * @var LaravelContainerInterface A Laravel Container

--- a/src/Adapter/NetteContainerAdapter.php
+++ b/src/Adapter/NetteContainerAdapter.php
@@ -4,14 +4,14 @@ namespace Acclimate\Container\Adapter;
 
 use Acclimate\Container\Exception\ContainerException as AcclimateContainerException;
 use Acclimate\Container\Exception\NotFoundException as AcclimateNotFoundException;
-use Interop\Container\ContainerInterface as AcclimateContainerInterface;
+use Psr\Container\ContainerInterface;
 use Nette\DI\Container as NetteContainerInterface;
 use Nette\DI\MissingServiceException as NetteNotFoundException;
 
 /**
  * An adapter from a Nette Container to the standardized ContainerInterface
  */
-class NetteContainerAdapter implements AcclimateContainerInterface
+class NetteContainerAdapter implements ContainerInterface
 {
     /**
      * @var NetteContainerInterface Nette Container

--- a/src/Adapter/PHPDIContainerAdapter.php
+++ b/src/Adapter/PHPDIContainerAdapter.php
@@ -6,12 +6,12 @@ use Acclimate\Container\Exception\ContainerException as AcclimateContainerExcept
 use Acclimate\Container\Exception\NotFoundException as AcclimateNotFoundException;
 use DI\Container as PhpDiContainerInterface;
 use DI\NotFoundException as PhpDiNotFoundException;
-use Interop\Container\ContainerInterface as AcclimateContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * An adapter from a PHP-DI Container to the standardized ContainerInterface
  */
-class PHPDIContainerAdapter implements AcclimateContainerInterface
+class PHPDIContainerAdapter implements ContainerInterface
 {
     /**
      * @var PhpDiContainerInterface A PHP-DI Container

--- a/src/Adapter/PhalconDIContainerAdapter.php
+++ b/src/Adapter/PhalconDIContainerAdapter.php
@@ -2,16 +2,16 @@
 
 namespace Acclimate\Container\Adapter;
 
-use Interop\Container\ContainerInterface as AcclimateContainerInterface;
 use Acclimate\Container\Exception\NotFoundException as AcclimateNotFoundException;
 use Acclimate\Container\Exception\ContainerException as AcclimateContainerException;
 use Phalcon\DiInterface as PhalconDI;
 use Phalcon\DI\Exception as PhalconDIException;
+use Psr\Container\ContainerInterface;
 
 /**
  * An adapter from an object implementing Phalcon\DiInterface to the standardized ContainerInterface
  */
-class PhalconDIContainerAdapter implements AcclimateContainerInterface
+class PhalconDIContainerAdapter implements ContainerInterface
 {
     /**
      * @var \Phalcon\DiInterface Phalcons DI container object

--- a/src/Adapter/PimpleContainerAdapter.php
+++ b/src/Adapter/PimpleContainerAdapter.php
@@ -4,13 +4,13 @@ namespace Acclimate\Container\Adapter;
 
 use Acclimate\Container\Exception\ContainerException as AcclimateContainerException;
 use Acclimate\Container\Exception\NotFoundException as AcclimateNotFoundException;
-use Interop\Container\ContainerInterface as AcclimateContainerInterface;
+use Psr\Container\ContainerInterface;
 use Pimple\Container as Pimple;
 
 /**
  * An adapter from a Pimple Container to the standardized ContainerInterface
  */
-class PimpleContainerAdapter implements AcclimateContainerInterface
+class PimpleContainerAdapter implements ContainerInterface
 {
     /**
      * @var Pimple A Pimple Container

--- a/src/Adapter/SymfonyContainerAdapter.php
+++ b/src/Adapter/SymfonyContainerAdapter.php
@@ -4,7 +4,7 @@ namespace Acclimate\Container\Adapter;
 
 use Acclimate\Container\Exception\ContainerException as AcclimateContainerException;
 use Acclimate\Container\Exception\NotFoundException as AcclimateNotFoundException;
-use Interop\Container\ContainerInterface as AcclimateContainerInterface;
+use Psr\Container\ContainerInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface as SymfonyContainerInterface;
 use Symfony\Component\DependencyInjection\Exception\InvalidArgumentException as SymfonyInvalidArgumentException;
 use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException as SymfonyNotFoundException;
@@ -12,7 +12,7 @@ use Symfony\Component\DependencyInjection\Exception\ServiceNotFoundException as 
 /**
  * An adapter from a Symfony Container to the standardized ContainerInterface
  */
-class SymfonyContainerAdapter implements AcclimateContainerInterface
+class SymfonyContainerAdapter implements ContainerInterface
 {
     /**
      * @var SymfonyContainerInterface A Symfony Container

--- a/src/Adapter/ZendDiContainerAdapter.php
+++ b/src/Adapter/ZendDiContainerAdapter.php
@@ -4,13 +4,13 @@ namespace Acclimate\Container\Adapter;
 
 use Acclimate\Container\Exception\ContainerException as AcclimateContainerException;
 use Acclimate\Container\Exception\NotFoundException as AcclimateNotFoundException;
-use Interop\Container\ContainerInterface as AcclimateContainerInterface;
+use Psr\Container\ContainerInterface;
 use Zend\Di\LocatorInterface;
 
 /**
  * An adapter from a Zend DIC to the standardized ContainerInterface
  */
-class ZendDiContainerAdapter implements AcclimateContainerInterface
+class ZendDiContainerAdapter implements ContainerInterface
 {
     /**
      * @var LocatorInterface A Zend DIC/ServiceLocator

--- a/src/Adapter/ZendServiceManagerContainerAdapter.php
+++ b/src/Adapter/ZendServiceManagerContainerAdapter.php
@@ -4,14 +4,14 @@ namespace Acclimate\Container\Adapter;
 
 use Acclimate\Container\Exception\ContainerException as AcclimateContainerException;
 use Acclimate\Container\Exception\NotFoundException as AcclimateNotFoundException;
-use Interop\Container\ContainerInterface as AcclimateContainerInterface;
+use Psr\Container\ContainerInterface;
 use Zend\ServiceManager\Exception\ServiceNotFoundException as ZendNotFoundException;
 use Zend\ServiceManager\ServiceLocatorInterface;
 
 /**
  * An adapter from a Zend ServiceManager/ServiceLocator to the standardized ContainerInterface
  */
-class ZendServiceManagerContainerAdapter implements AcclimateContainerInterface
+class ZendServiceManagerContainerAdapter implements ContainerInterface
 {
     /**
      * @var ServiceLocatorInterface A Zend ServiceManager/ServiceLocator

--- a/src/ArrayContainer.php
+++ b/src/ArrayContainer.php
@@ -2,7 +2,7 @@
 
 namespace Acclimate\Container;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Acclimate\Container\Exception\ContainerException;
 use Acclimate\Container\Exception\NotFoundException;
 

--- a/src/CompositeContainer.php
+++ b/src/CompositeContainer.php
@@ -2,7 +2,7 @@
 
 namespace Acclimate\Container;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 use Acclimate\Container\Exception\NotFoundException;
 
 /**

--- a/src/ContainerAcclimator.php
+++ b/src/ContainerAcclimator.php
@@ -3,7 +3,7 @@
 namespace Acclimate\Container;
 
 use Acclimate\Container\Exception\InvalidAdapterException;
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * This class is used to "acclimate", or adapt, a container object (e.g., DIC, SL) to a common ContainerInterface. In

--- a/src/Decorator/AbstractContainerDecorator.php
+++ b/src/Decorator/AbstractContainerDecorator.php
@@ -2,7 +2,7 @@
 
 namespace Acclimate\Container\Decorator;
 
-use Interop\Container\ContainerInterface;
+use Psr\Container\ContainerInterface;
 
 /**
  * An abstract ContainerDecorator that allows you to decorate a container and proxy to the decorated container

--- a/src/Decorator/CallbackOnMissContainer.php
+++ b/src/Decorator/CallbackOnMissContainer.php
@@ -2,8 +2,8 @@
 
 namespace Acclimate\Container\Decorator;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\NotFoundException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
 
 /**
  * A container decorator that changes the default behavior of throwing an exception when an item doesn't exist in the
@@ -36,7 +36,7 @@ class CallbackOnMissContainer extends AbstractContainerDecorator
     {
         try {
             return $this->container->get($id);
-        } catch (NotFoundException $e) {
+        } catch (NotFoundExceptionInterface $e) {
             return call_user_func($this->callback, $id);
         }
     }

--- a/src/Decorator/FailoverOnMissContainer.php
+++ b/src/Decorator/FailoverOnMissContainer.php
@@ -2,8 +2,8 @@
 
 namespace Acclimate\Container\Decorator;
 
-use Interop\Container\ContainerInterface;
-use Interop\Container\Exception\NotFoundException;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
 
 /**
  * A container decorator that delegates to a designated failover container if the decorated container does not contain
@@ -30,7 +30,7 @@ class FailoverOnMissContainer extends AbstractContainerDecorator
     {
         try {
             return $this->container->get($id);
-        } catch (NotFoundException $e) {
+        } catch (NotFoundExceptionInterface $e) {
             return $this->failoverContainer->get($id);
         }
     }

--- a/src/Decorator/NullOnMissContainer.php
+++ b/src/Decorator/NullOnMissContainer.php
@@ -2,7 +2,7 @@
 
 namespace Acclimate\Container\Decorator;
 
-use Interop\Container\Exception\NotFoundException;
+use Psr\Container\NotFoundExceptionInterface;
 
 /**
  * A container decorator that changes the default behavior of throwing an exception when an item doesn't exist in the
@@ -14,7 +14,7 @@ class NullOnMissContainer extends AbstractContainerDecorator
     {
         try {
             return $this->container->get($id);
-        } catch (NotFoundException $e) {
+        } catch (NotFoundExceptionInterface $e) {
             return null;
         }
     }

--- a/src/Exception/ContainerException.php
+++ b/src/Exception/ContainerException.php
@@ -2,12 +2,12 @@
 
 namespace Acclimate\Container\Exception;
 
-use Interop\Container\Exception\ContainerException as InteropContainerException;
+use Psr\Container\ContainerExceptionInterface;
 
 /**
  * An error occurred when trying to retrieve an entry from the container
  */
-class ContainerException extends \RuntimeException implements InteropContainerException
+class ContainerException extends \RuntimeException implements ContainerExceptionInterface
 {
     /**
      * @var string The message template. Allowed variables are {error} and {id}

--- a/src/Exception/NotFoundException.php
+++ b/src/Exception/NotFoundException.php
@@ -2,14 +2,14 @@
 
 namespace Acclimate\Container\Exception;
 
-use Interop\Container\Exception\NotFoundException as InteropNotFoundException;
+use Psr\Container\NotFoundExceptionInterface;
 
 /**
  * No entry was found in the container
  *
  * @method static NotFoundException fromPrevious($id, \Exception $prev = null)
  */
-class NotFoundException extends ContainerException implements InteropNotFoundException
+class NotFoundException extends ContainerException implements NotFoundExceptionInterface
 {
     protected static $template = 'There is no entry found in the container for the identifier "{id}".';
 }

--- a/tests/Adapter/AbstractContainerAdapterTest.php
+++ b/tests/Adapter/AbstractContainerAdapterTest.php
@@ -2,6 +2,10 @@
 
 namespace Acclimate\Container\Test\Adapter;
 
+use Acclimate\Container\Exception\ContainerException;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
 use PHPUnit\Framework\TestCase;
 
 abstract class AbstractContainerAdapterTest extends TestCase
@@ -21,7 +25,7 @@ abstract class AbstractContainerAdapterTest extends TestCase
 
         $this->assertFalse($container->has('foo'));
 
-        $this->expectException('Interop\Container\Exception\NotFoundException');
+        $this->expectException(NotFoundExceptionInterface::class);
         $container->get('foo');
     }
 
@@ -32,13 +36,13 @@ abstract class AbstractContainerAdapterTest extends TestCase
         try {
             $container->get('error');
         } catch (\Exception $e) {
-            $this->assertInstanceOf('Interop\Container\Exception\ContainerException', $e);
-            $this->assertEquals('Acclimate\Container\Exception\ContainerException', get_class($e));
+            $this->assertInstanceOf(ContainerExceptionInterface::class, $e);
+            $this->assertEquals(ContainerException::class, get_class($e));
         }
     }
 
     /**
-     * @return \Interop\Container\ContainerInterface
+     * @return ContainerInterface
      */
     abstract protected function createContainer();
 }

--- a/tests/Adapter/SymfonyContainerAdapterTest.php
+++ b/tests/Adapter/SymfonyContainerAdapterTest.php
@@ -3,6 +3,7 @@
 namespace Acclimate\Container\Test\Adapter;
 
 use Acclimate\Container\Adapter\SymfonyContainerAdapter;
+use Psr\Container\NotFoundExceptionInterface;
 use Symfony\Component\DependencyInjection\Container;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Component\DependencyInjection\Definition;
@@ -30,7 +31,7 @@ class SymfonyContainerAdapterTest extends AbstractContainerAdapterTest
     {
         $container = new SymfonyContainerAdapter(new Container());
 
-        $this->expectException('Interop\Container\Exception\NotFoundException');
+        $this->expectException(NotFoundExceptionInterface::class);
         $container->get('foo');
     }
 }

--- a/tests/ArrayContainerTest.php
+++ b/tests/ArrayContainerTest.php
@@ -3,8 +3,10 @@
 namespace Acclimate\Container\Test;
 
 use Acclimate\Container\ArrayContainer;
-use Interop\Container\ContainerInterface;
 use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerExceptionInterface;
+use Psr\Container\ContainerInterface;
+use Psr\Container\NotFoundExceptionInterface;
 
 /**
  * @covers \Acclimate\Container\ArrayContainer
@@ -41,7 +43,7 @@ class ArrayContainerTest extends TestCase
 
         $this->assertFalse($container->has('foo'));
 
-        $this->expectException('Interop\Container\Exception\NotFoundException');
+        $this->expectException(NotFoundExceptionInterface::class);
         $container->get('foo');
     }
 
@@ -52,7 +54,7 @@ class ArrayContainerTest extends TestCase
             throw new \RuntimeException;
         };
 
-        $this->expectException('Interop\Container\Exception\ContainerException');
+        $this->expectException(ContainerExceptionInterface::class);
         $container->get('error');
     }
 

--- a/tests/CompositeContainerTest.php
+++ b/tests/CompositeContainerTest.php
@@ -7,6 +7,7 @@ use Acclimate\Container\ArrayContainer;
 use Acclimate\Container\CompositeContainer;
 use PHPUnit\Framework\TestCase;
 use Pimple\Container as Pimple;
+use Psr\Container\NotFoundExceptionInterface;
 
 /**
  * @covers \Acclimate\Container\CompositeContainer
@@ -33,7 +34,7 @@ class CompositeContainerTest extends TestCase
 
         $this->assertFalse($container->has('foo'));
 
-        $this->expectException('Interop\Container\Exception\NotFoundException');
+        $this->expectException(NotFoundExceptionInterface::class);
         $container->get('foo');
     }
 
@@ -43,7 +44,7 @@ class CompositeContainerTest extends TestCase
 
         $this->assertFalse($container->has('foo'));
 
-        $this->expectException('Interop\Container\Exception\NotFoundException');
+        $this->expectException(NotFoundExceptionInterface::class);
         $container->get('foo');
     }
 }

--- a/tests/ContainerAcclimatorTest.php
+++ b/tests/ContainerAcclimatorTest.php
@@ -6,6 +6,7 @@ use Acclimate\Container\ContainerAcclimator;
 use Acclimate\Container\ArrayContainer;
 use PHPUnit\Framework\TestCase;
 use Pimple\Container as Pimple;
+use Psr\Container\ContainerInterface;
 
 /**
  * @covers \Acclimate\Container\ContainerAcclimator
@@ -25,7 +26,7 @@ class ContainerAcclimatorTest extends TestCase
         $acclimator = new ContainerAcclimator();
         $pimpleContainer = $this->getMockBuilder(Pimple::class)->getMock();
         $container = $acclimator->acclimate($pimpleContainer);
-        $this->assertInstanceOf('Interop\Container\ContainerInterface', $container);
+        $this->assertInstanceOf(ContainerInterface::class, $container);
     }
 
     public function testCanRegisterOtherAdapters()
@@ -41,7 +42,7 @@ class ContainerAcclimatorTest extends TestCase
     {
         $acclimator = new ContainerAcclimator();
         $container = $acclimator->acclimate(new \ArrayObject);
-        $this->assertInstanceOf('Interop\Container\ContainerInterface', $container);
+        $this->assertInstanceOf(ContainerInterface::class, $container);
     }
 
     public function testThrowsExceptionOnContainersThatCannotBeAdpated()


### PR DESCRIPTION
The [Container-Interop](https://github.com/container-interop/container-interop) standard is now deprecated, in favour of [PSR-11](https://github.com/php-fig/container).  This PR switches Acclimate over from Container-Interop to PSR-11.