### PR TITLE
Add compatibility with psr/container 2.0

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     ],
     "require": {
         "php": ">=5.6.0",
-        "psr/container": "^1.0"
+        "psr/container": "^1.0|^2.0"
     },
     "require-dev": {
         "aura/di": "^1.0",

--- a/src/Adapter/ArrayAccessContainerAdapter.php
+++ b/src/Adapter/ArrayAccessContainerAdapter.php
@@ -37,7 +37,7 @@ class ArrayAccessContainerAdapter implements AcclimateContainerInterface
         }
     }
 
-    public function has($id)
+    public function has($id): bool
     {
         return isset($this->container[$id]);
     }

--- a/src/Adapter/AuraContainerAdapter.php
+++ b/src/Adapter/AuraContainerAdapter.php
@@ -37,7 +37,7 @@ class AuraContainerAdapter implements AcclimateContainerInterface
         }
     }
 
-    public function has($id)
+    public function has($id): bool
     {
         return $this->container->has($id);
     }

--- a/src/Adapter/LaravelContainerAdapter.php
+++ b/src/Adapter/LaravelContainerAdapter.php
@@ -38,7 +38,7 @@ class LaravelContainerAdapter implements ContainerInterface
         }
     }
 
-    public function has($id)
+    public function has($id): bool
     {
         return $this->container->bound($id);
     }

--- a/src/Adapter/NetteContainerAdapter.php
+++ b/src/Adapter/NetteContainerAdapter.php
@@ -37,7 +37,7 @@ class NetteContainerAdapter implements ContainerInterface
         }
     }
 
-    public function has($id)
+    public function has($id): bool
     {
         return $this->container->hasService($id);
     }

--- a/src/Adapter/PHPDIContainerAdapter.php
+++ b/src/Adapter/PHPDIContainerAdapter.php
@@ -37,7 +37,7 @@ class PHPDIContainerAdapter implements ContainerInterface
         }
     }
 
-    public function has($id)
+    public function has($id): bool
     {
         try {
             $this->container->get($id);

--- a/src/Adapter/PhalconDIContainerAdapter.php
+++ b/src/Adapter/PhalconDIContainerAdapter.php
@@ -37,7 +37,7 @@ class PhalconDIContainerAdapter implements ContainerInterface
         }
     }
 
-    public function has($id)
+    public function has($id): bool
     {
         return isset($this->container[$id]);
     }

--- a/src/Adapter/PimpleContainerAdapter.php
+++ b/src/Adapter/PimpleContainerAdapter.php
@@ -36,7 +36,7 @@ class PimpleContainerAdapter implements ContainerInterface
         }
     }
 
-    public function has($id)
+    public function has($id): bool
     {
         return isset($this->container[$id]);
     }

--- a/src/Adapter/SymfonyContainerAdapter.php
+++ b/src/Adapter/SymfonyContainerAdapter.php
@@ -40,7 +40,7 @@ class SymfonyContainerAdapter implements ContainerInterface
         }
     }
 
-    public function has($id)
+    public function has($id): bool
     {
         return $this->container->has($id);
     }

--- a/src/Adapter/ZendDiContainerAdapter.php
+++ b/src/Adapter/ZendDiContainerAdapter.php
@@ -40,7 +40,7 @@ class ZendDiContainerAdapter implements ContainerInterface
         return $result;
     }
 
-    public function has($id)
+    public function has($id): bool
     {
         return ($this->container->get($id) !== null);
     }

--- a/src/Adapter/ZendServiceManagerContainerAdapter.php
+++ b/src/Adapter/ZendServiceManagerContainerAdapter.php
@@ -37,7 +37,7 @@ class ZendServiceManagerContainerAdapter implements ContainerInterface
         }
     }
 
-    public function has($id)
+    public function has($id): bool
     {
         return $this->container->has($id);
     }

--- a/src/ArrayContainer.php
+++ b/src/ArrayContainer.php
@@ -17,7 +17,7 @@ class ArrayContainer implements ContainerInterface, \ArrayAccess
      * @var array|\ArrayAccess The container data
      */
     protected $data;
-    
+
     /**
      * @var ContainerInterface The container that will be used for dependency lookups
      */
@@ -57,7 +57,7 @@ class ArrayContainer implements ContainerInterface, \ArrayAccess
         }
     }
 
-    public function has($identifier)
+    public function has($identifier): bool
     {
         return isset($this->data[$identifier]);
     }

--- a/src/CompositeContainer.php
+++ b/src/CompositeContainer.php
@@ -62,7 +62,7 @@ class CompositeContainer implements ContainerInterface
      *
      * {@inheritDoc}
      */
-    public function has($id)
+    public function has($id): bool
     {
         /** @var ContainerInterface $container */
         foreach ($this->containers as $container) {

--- a/src/Decorator/AbstractContainerDecorator.php
+++ b/src/Decorator/AbstractContainerDecorator.php
@@ -27,7 +27,7 @@ abstract class AbstractContainerDecorator implements ContainerInterface
         return $this->container->get($name);
     }
 
-    public function has($name)
+    public function has($name): bool
     {
         return $this->container->has($name);
     }


### PR DESCRIPTION
Adding return types to existing implementations will still be compatible with psr/container 1.0 also because of PHP's covariance rules, while adding compatibility with psr/container 2.0. Leaving off parameter types similarly will maintain compatibility with both as per PHP's contravariance rules.